### PR TITLE
Tietokannan tyhjennys hyödyntämään tietokannan luomisfunktiota ja utf-8:n korjaaminen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ Sulkee sovelluksen. Kaikki antamasi vinkit säilyvät sovelluksessa.
 - `uusi` - lisää uusi vinkki, joko kirja tai artikkeli
 
 Lisää uusi vinkki kirjastoon. Spesifioi, haluatko lisätä kirjan vai artikkelin, ja anna sitten pyydetty info.
+

--- a/Vinkkikirjasto/build.gradle
+++ b/Vinkkikirjasto/build.gradle
@@ -23,6 +23,12 @@ dependencies {
     testCompile 'junit:junit:' + junitVersion
 }
 
+compileJava.options.encoding = 'UTF-8'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 jar {
     manifest {
         attributes 'Main-Class': 'library.ui.Main'
@@ -47,6 +53,8 @@ jacocoTestReport {
         html.enabled true
     }
 }
+
 test {
-  testLogging.showStandardStreams = true
+    testLogging.showStandardStreams = true
+    systemProperty 'file.encoding', 'utf-8'
 }

--- a/Vinkkikirjasto/src/main/java/library/dao/SQLLibraryDao.java
+++ b/Vinkkikirjasto/src/main/java/library/dao/SQLLibraryDao.java
@@ -391,20 +391,6 @@ public class SQLLibraryDao implements LibraryDao {
     }
 
     public void clearDatabase() {
-        try {
-            Connection conn = connect();
-
-            Statement s = conn.createStatement();
-
-            s.execute("DELETE FROM Author");
-            s.execute("DELETE FROM Book");
-            s.execute("DELETE FROM Article");
-
-            s.close();
-            conn.close();
-
-        } catch (Exception e) {
-            System.out.println(e.getMessage());
-        }
+        this.createDatabase();
     }
 }


### PR DESCRIPTION
Yksinkertaistin tietokannan tyhjentämiseen käytettävää funktiota laittamalla sen kutsumaan tietokannan luomiseen tarkoitettua funktiota.

Lisäksi lisäsin build.gradle-tiedostoon utf-8-tukeen liittyviä tietoja, sillä itselläni ääkkösiä sisältävät testit eivät menneet läpi ilman.